### PR TITLE
If the target is a thumbnail with no target, select the parent element

### DIFF
--- a/lib/extension.js
+++ b/lib/extension.js
@@ -160,6 +160,8 @@ BZ = BetterZoom = {
     }, 500);
   },
   processLink: function(ele) {
+    if(ele.target === undefined)
+      ele = ele.parentNode;
     BZ.checkLinkForGenericMedia(ele)
       .then(function(mediaData) {
         return BZ.checkLinkForMedia(mediaData);

--- a/lib/extension.js
+++ b/lib/extension.js
@@ -467,7 +467,7 @@ BZ = BetterZoom = {
       var data = {
         link: link
       };
-      if ((/\.(jpg|jpeg|png|apng|gif)$/ig).test(link.href)) {
+      if ((/\.(jpg|jpeg|png|apng|gif|.jpg)(\?.*)?$/ig).test(link.href)) {
         data.type = 'img';
         data.src = link.href;
       }


### PR DESCRIPTION
I'm not sure if this is the best solution, but I always hover over the thumbnail to expand, not the link. 

This may stop any expansion we do on raw images... do we expand raw images?
