### PR TITLE
Adds support for images that end with php GET vars

### DIFF
--- a/lib/extension.js
+++ b/lib/extension.js
@@ -465,7 +465,7 @@ BZ = BetterZoom = {
       var data = {
         link: link
       };
-      if ((/\.(jpg|jpeg|png|apng|gif)$/ig).test(link.href)) {
+     if ((/\.(jpg|jpeg|png|apng|gif|.jpg)(\?.*)?$/ig).test(link.href)) {
         data.type = 'img';
         data.src = link.href;
       }


### PR DESCRIPTION
Ex.
Post:
http://www.reddit.com/r/PerfectTiming/comments/1zfvxy/after_a_pilots_first_combat_mission/
Link:
http://i.imgur.com/HlfzA7S.jpg?1

The ?1 previously prevented the regex from successfully matching
