### PR TITLE
Added wikipedia support

### DIFF
--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -21,6 +21,7 @@
 				"BabelExt.js",
 				"extension.js",
 				"modules/imgur.js",
+				"modules/wikipedia.js",
 				"modules/flickr.js"
 			] // add others here if you like, i.e. jquery...
 		}

--- a/lib/extension.js
+++ b/lib/extension.js
@@ -160,6 +160,8 @@ BZ = BetterZoom = {
     }, 500);
   },
   processLink: function(ele) {
+    if(ele.target === undefined && ele.parentNode !== undefined && ele.parentNode.target !== undefined)
+      ele = ele.parentNode;
     BZ.checkLinkForGenericMedia(ele)
       .then(function(mediaData) {
         return BZ.checkLinkForMedia(mediaData);
@@ -484,7 +486,7 @@ BZ = BetterZoom = {
   getSiteModule: function (host) {
     var module, mapping;
 
-    host = host.replace('www.','');
+    host = host.split(".").slice(-2).join(".");
 
     module = this.siteModules[host];
     mapping = this.domainToSiteModule[host];

--- a/lib/modules/wikipedia.js
+++ b/lib/modules/wikipedia.js
@@ -1,0 +1,37 @@
+  BZ.addModule(
+    'wikipedia.org', 
+    function (wikipedia, moduleID) {
+      $.extend(wikipedia, {
+        domains: ['en.wikipedia.org'],
+        apiPrefix: 'http://en.wikipedia.org/w/api.php',
+        hashRe: /^((http(s)?:\/\/)?.*\.)?wikipedia.org\/wiki\/File:([A-Za-z0-9_\-]*)?.(png|gif|jpg|jpeg)$/i,
+        calls: {},
+        checkLinkForMedia: function(mediaData) {
+          var href = mediaData.link.href.split('?')[0];
+          var promise = new RSVP.Promise(function(resolve, reject) {
+            if(wikipedia.hashRe.exec(href)){
+             console.log('make call wikipedia',href);
+             $.ajax({
+              method: 'GET',
+              dataType: "html",
+              url: href,
+              success: function(response) {
+                var result = $(response);
+                var link = "http://"+result.find(".fullImageLink").find("a").attr('href').replace("//","");
+                console.log("Direct link:",link);
+                mediaData.src = link;
+                resolve(mediaData);
+              },
+              error: function(response) {
+                reject();
+              }
+            });
+           }else{
+            reject();
+          }
+        });
+          return promise;
+        }
+      }); 
+    }
+  );


### PR DESCRIPTION
Requires the thumbnail fix and a change to how hostname is determined.
The hostname change is required to support *.wikipedia.org and other sites
with multiple possible starts to the domain name. It splits at peiods,
then throws away all but the last two items before recombining, ie.

en.wikipedia.org -> 'en','wikipedia','org' -> 'wikipedia','org',
wikipedia.org

www.imgur.com -> 'www','imgur','com' -> 'imgur','com', -> imgur.com

Breaks on multiple .domains like .co.uk though. A better solution may be
needed.

Finally, I found where the modules need to be listed in chrome's manifest,
but I haven't tested this with any of the other browsers.
